### PR TITLE
[INFRA-2263] Go-public prep for proof/x401 (README, CONTRIBUTING, CODEOWNERS)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners for proof/x401.
+#
+# Branch protection on `main` requires a review from a code owner on every PR.
+# The owners below are automatically requested for review when a PR is opened.
+# Adjust to the appropriate team or individuals as ownership settles.
+
+# Default owner for everything in the repository.
+* @proof/proof-product

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for your interest in x401. This repository holds the protocol specification and a
+small local demo of the [x401 HTTP Proof Requirement Protocol](https://x401.proof.com/spec).
+
+## Requirements
+
+- Node.js (current LTS)
+- npm
+
+## Getting started
+
+```
+npm ci
+npm run spec:dev      # live-reloading spec preview
+npm run site:build    # build the static site into www/
+npm test              # run the test suite
+```
+
+## Scope
+
+x401 defines HTTP proof-requirement semantics only. Please keep changes within that boundary:
+
+- The protocol is header-driven (`PROOF-REQUIRED`, `PROOF-PRESENTATION`, `PROOF-RESPONSE`).
+- x401 composes with, but does not redefine, payment protocols — payment stays on
+  `402 Payment Required`.
+- Credential formats and wallet transport (OpenID4VP request construction) are out of scope
+  for the core protocol.
+
+## Pull requests
+
+- Fork the repo and branch off of `main`.
+- For substantive protocol changes, open an issue first so the approach can be discussed.
+- Include a clear title and description explaining what changed and why.
+- Keep changes focused — try to limit one issue or feature per PR.
+- Record user-facing spec changes in [CHANGELOG.md](CHANGELOG.md).
+
+## Code of conduct
+
+This project follows the
+[Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+By participating, you are expected to uphold this standard.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # x401
+
+The **x401 HTTP Proof Requirement Protocol** specification.
+
+x401 defines an HTTP-native, route-scoped protocol for requiring credential-based proof
+before access to a protected resource is granted. A server (the _verifier_) advertises a
+proof requirement with a `PROOF-REQUIRED` header; a user _agent_ retries with a
+`PROOF-PRESENTATION` header carrying a verifiable presentation — or a reusable
+proof-satisfaction token. x401 builds on DCQL, OpenID4VP, OAuth 2.0, and OpenID4VCI, and
+composes with — but does not redefine — payment protocols (`402 Payment Required`).
+
+📄 **Read the specification:** <https://x401.proof.com/spec>
+
+## Repository layout
+
+| Path | Purpose |
+| --- | --- |
+| `spec.md`, `specs.json` | Specification source ([spec-up](https://github.com/decentralized-identity/spec-up) inputs) |
+| `scripts/` | Build entry points that render the spec and static site |
+| `public/` | Static assets for the rendered site |
+| `CHANGELOG.md` | Notable changes to the specification |
+
+## Building locally
+
+```
+npm ci
+npm run spec:dev      # live-reloading spec preview
+npm run site:build    # build the static site into www/
+npm test
+```
+
+## Implementations
+
+- [`@proof.com/x401-node`](https://github.com/proof/x401-node) — Node.js SDK for verifiers and agents.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+[Apache 2.0](LICENSE).


### PR DESCRIPTION
## Summary

Go-public prep for `proof/x401`, per the [Publishing Open Source](https://notarize.atlassian.net/wiki/spaces/EN/pages/5360812039/Publishing+Open+Source) standard. This PR carries the **file** changes; repo/integration settings (which can't live in a diff) are applied out-of-band and tracked below.

### Files in this PR
- **`README.md`** — what x401 is, repo layout, local build, links to the spec and the `x401-node` SDK.
- **`CONTRIBUTING.md`** — requirements, getting started, scope boundary, PR guidance, Contributor Covenant.
- **`CODEOWNERS`** — `* @proof/proof-product` (default owner; branch protection on `main` requires code-owner review). Adjust the owner if a different team/individual should gate merges.

`LICENSE` (Apache 2.0) is already present.

### Settings applied out-of-band (this ticket)
- ✅ Wiki disabled (`has_wiki=false`) — separate public git repo, not needed.
- ✅ Projects disabled (`has_projects=false`) — this repo is just the spec/site; SDK/tracking lives elsewhere. Issues kept **on** (the spec's "file an issue" link).

### Remaining manual steps before the public flip
- ⏳ **Enable forking** — blocked while the repo is private (org disallows private-repo forking); flip `allow_forking=true` at/after the public switch.
- ⏳ **Cloudflare Pages: restrict preview deployments** — in the Pages project → *Settings → Builds & deployments → Preview deployments*, limit to the production branch (or collaborators / require approval). Otherwise, once public, a fork PR that removes `functions/_middleware.js` yields an ungated public `*.pages.dev` preview, and PR builds run arbitrary repo code on Cloudflare's infra.
- ⏳ History rewrite of `main` to drop the internal-plumbing content in `docs/superpowers/*` (commits `a173687`, `311c22d`, removed in `466a423`).
- ⏳ Prune stale branches; decide PR #1 / PR #7 disposition.
- ⏳ Reconcile spec domain (`x401.id` in schema `$id`s vs `x401.proof.com/spec` in SDK/docs).
- ⏳ InfoSec (John) + CloudInfra sign-off.

## Test plan
- [ ] All three files render correctly on GitHub.
- [ ] README build/run commands match `package.json` scripts (`npm ci`; `npm run spec:dev`; `npm run site:build`; `npm test`).
- [ ] Intra-repo links resolve (`CONTRIBUTING.md`, `CHANGELOG.md`, `LICENSE`).
- [ ] CODEOWNERS references a valid team (`@proof/proof-product`).
